### PR TITLE
Works fine with argparse 1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     packages=find_packages(where='src'),
     entry_points={'console_scripts': ['jsonpipe = jsonpipe:main',
                                       'jsonunpipe = jsonpipe:main_unpipe']},
-    install_requires=['simplejson>=2.1.3', 'argparse>=1.2.1', 'calabash>=0.0.2'],
+    install_requires=['simplejson>=2.1.3', 'argparse>=1.1', 'calabash>=0.0.2'],
     test_suite='jsonpipe._get_tests',
 )


### PR DESCRIPTION
I am currently using it with argparse 1.1 without any issues.

It seems the only changes after 1.1 are related to license changes and other needed changes for the integration into Python 2.7.
