### PR TITLE
Remove simplejson dependency for Python>=2.7

### DIFF
--- a/src/jsonpipe/__init__.py
+++ b/src/jsonpipe/__init__.py
@@ -3,7 +3,12 @@
 import sys
 
 import argparse
-import simplejson
+try:
+    import simplejson
+    OrderedDict = simplejson.OrderedDict
+except ImportError:
+    import json as simplejson
+    from collections import OrderedDict
 
 from pipe import jsonpipe, jsonunpipe
 
@@ -65,7 +70,7 @@ def main():
 
     # Load JSON from stdin, preserving the order of object keys.
     json_obj = simplejson.load(sys.stdin,
-                               object_pairs_hook=simplejson.OrderedDict)
+                               object_pairs_hook=OrderedDict)
     for line in jsonpipe(json_obj, pathsep=args.separator):
         print line
 
@@ -76,5 +81,5 @@ def main_unpipe():
     simplejson.dump(
         jsonunpipe(iter(sys.stdin), pathsep=args.separator,
                    decoder=simplejson.JSONDecoder(
-                       object_pairs_hook=simplejson.OrderedDict)),
+                       object_pairs_hook=OrderedDict)),
         sys.stdout)

--- a/src/jsonpipe/pipe.py
+++ b/src/jsonpipe/pipe.py
@@ -1,4 +1,7 @@
-import simplejson
+try:
+    import simplejson
+except ImportError:
+    import json as simplejson
 
 
 __all__ = ['jsonpipe', 'jsonunpipe']

--- a/src/jsonpipe/sh.py
+++ b/src/jsonpipe/sh.py
@@ -1,7 +1,10 @@
 import re
 
 import calabash
-import simplejson
+try:
+    import simplejson
+except ImportError:
+    import json as simplejson
 
 import jsonpipe as jp
 


### PR DESCRIPTION
Even though the json module is in Python 2.6, OrderedDict is only present in 2.7.
